### PR TITLE
Fix issue with emulator on Wayland

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -19,6 +19,7 @@
         "--talk-name=ca.desrt.dconf",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--env=ANDROID_EMULATOR_USE_SYSTEM_LIBS=1",
+        "--env=QT_QPA_PLATFORM=",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.Notifications"
     ],


### PR DESCRIPTION
Fixes "could not find or load the Qt platform plugin 'wayland'"