### PR TITLE
Set additional ENV variables

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -12,6 +12,8 @@
         "--share=ipc",
         "--share=network",
         "--device=all",
+        "--env=ANDROID_EMULATOR_USE_SYSTEM_LIBS=1",
+        "--env=JAVA_HOME=/app/extra/android-studio/jre",
         "--filesystem=host",
         "--allow=multiarch",
         "--talk-name=org.freedesktop.Notifications",


### PR DESCRIPTION
Hi, following some discussion I have added these two ENV variables.
JAVA HOME now points to Android Studio's embedded jre