### PR TITLE
Fix Git commit error and set JAVA_HOME

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -14,6 +14,8 @@
         "--device=all",
         "--filesystem=host",
         "--allow=multiarch",
+        "--env=_JAVA_OPTIONS=-Djava.io.tmpdir=$XDG_CACHE_HOME/tmp/",
+        "--env=JAVA_HOME=/app/extra/android-studio/jre",
         "--talk-name=org.freedesktop.Notifications",
         "--talk-name=org.freedesktop.secrets",
         "--talk-name=org.freedesktop.Flatpak"


### PR DESCRIPTION
Java temporary directory was not set properly, leading to errors during the "Commit" phase

Setting JAVA_HOME to the bundled JRE with Android Studio allows applications to find the correct binaries inside