### PR TITLE
Fixed download size of extra data

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -52,7 +52,7 @@
                 {
                     "type": "extra-data",
                     "filename": "android-studio.tar.gz",
-                    "size": 766000000,
+                    "size": 803889879,
                     "only-arches": [
                         "x86_64"
                     ],


### PR DESCRIPTION
The manifest has the wrong download size for android-studio-ide-192.6241897-linux.tar.gz. Fixes #70 

Interestingly the sha256sum was already correct.

```
~ $ wget https://dl.google.com/dl/android/studio/ide-zips/3.6.1.0/android-studio-ide-192.6241897-linux.tar.gz
--2020-03-02 11:56:03--  https://dl.google.com/dl/android/studio/ide-zips/3.6.1.0/android-studio-ide-192.6241897-linux.tar.gz
CA-Zertifikat »/etc/ssl/certs/ca-certificates.crt« wurde geladen
Auflösen des Hostnamens dl.google.com (dl.google.com)… 2a00:1450:4001:820::200e, 216.58.205.238
Verbindungsaufbau zu dl.google.com (dl.google.com)|2a00:1450:4001:820::200e|:443 … verbunden.
HTTP-Anforderung gesendet, auf Antwort wird gewartet … 200 OK
Länge: 803889879 (767M) [application/octet-stream]
Wird in »android-studio-ide-192.6241897-linux.tar.gz« gespeichert.

android-studio-ide-192.6241897-linux.tar.gz                 100%[==========================================================================================================================================>] 766,65M  25,5MB/s    in 33s     

2020-03-02 11:56:37 (23,3 MB/s) - »android-studio-ide-192.6241897-linux.tar.gz« gespeichert [803889879/803889879]

                                                                                                                                                                                                                                               
~ $ ls -l android-studio-ide-192.6241897-linux.tar.gz
-rw-r--r-- 1 phw phw 803889879 28. Feb 19:00 android-studio-ide-192.6241897-linux.tar.gz
                                                                                                                                                                                                                                               
~ $ sha256sum android-studio-ide-192.6241897-linux.tar.gz 
e754dc9db31a5c222f230683e3898dcab122dfe7bdb1c4174474112150989fd7  android-studio-ide-192.6241897-linux.tar.gz
```