### PR TITLE
manifest: add EXTRA_PATH to allow passing a custom PATH

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -74,7 +74,7 @@
                     "commands": [
                         "if ! [ -n \"$XDG_CACHE_HOME\" ]; then export XDG_CACHE_HOME=$HOME/.cache; fi",
                         "export _JAVA_OPTIONS=-Djava.io.tmpdir=$XDG_CACHE_HOME",
-                        "exec /app/extra/android-studio/bin/studio.sh"
+                        "exec env \"PATH=$PATH:$EXTRA_PATH\" /app/extra/android-studio/bin/studio.sh"
                     ]
                 }
             ]


### PR DESCRIPTION
It seems that the Flatpak CLI does not allow to pass a certain PATH when running a Flatpak. In some cases, users might want to do that, still, at their own risk.

This allows the user to pass an EXTRA_PATH variable which will then get appended to the PATH for calling the IDE, allowing to run binaries/executables from the host.

Of course, that will eventually break. But then it is the user who actively opted into that breaking behavior by passing the variable.

Cf: https://github.com/flathub/com.jetbrains.IntelliJ-IDEA-Ultimate/commit/fd85a680f59fc6657b315bf1d5794cdb94d35b69