### PR TITLE
Add `patch` to bundled modules

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -117,6 +117,16 @@
                 }
             ]
         },
+        {
+            "name": "patch",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://ftp.gnu.org/gnu/patch/patch-2.7.6.tar.gz",
+                    "sha256": "8cf86e00ad3aaa6d26aca30640e86b0e3e1f395ed99f189b06d4c9f74bc58a4e"
+                }
+            ]
+        },
         "shared-modules/libsecret/libsecret.json"
     ]
 }


### PR DESCRIPTION
`patch` is necessary to build https://github.com/WireGuard/wireguard-android. I believe there are a number of projects using it, too.