### PR TITLE
Added ncurses5 build

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -124,6 +124,34 @@
                 }
             ]
         },
+        {
+            "name": "ncurses",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "ftp://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz",
+                    "sha256": "9046298fb440324c9d4135ecea7879ffed8546dd1b58e59430ea07a4633f563b"
+                }
+            ],
+            "buildsystem": "autotools",
+            "build-options": {
+                "cppflags": "-P"
+            },
+            "config-opts": [
+                "--with-shared",
+                "--with-termlib",
+                "--without-normal",
+                "--without-develop",
+                "--without-cxx",
+                "--without-tests",
+                "--without-progs",
+                "--without-manpages"
+            ],
+            "cleanup": [
+                 "/include",
+                 "/lib/*.a"
+            ]
+        },
         "shared-modules/libsecret/libsecret.json"
     ]
 }


### PR DESCRIPTION
Fixes #130 

* Provide `libncurses.so.5` required by android `LLDB` debugger
* Provide `libtinfo.so.5` required by android `LLDB` debugger

How to test:
1. Open a project with native components
2. Start the debugger (with native debugging enabled)
3. Debug the project