### PR TITLE
Dolphin 2021.3.1 Patch 1 & update dependencies

### DIFF
--- a/com.google.AndroidStudio.appdata.xml
+++ b/com.google.AndroidStudio.appdata.xml
@@ -29,7 +29,8 @@
 	<icon type="remote" height="128" width="128">https://1.bp.blogspot.com/-DAAJWGccTCQ/We_MGiMuSFI/AAAAAAAAEtk/5_COppUTDusIIx725jENI3fd9rqlRl0gQCLcBGAs/s128/image8.png</icon>
 	<icon type="remote" height="64" width="64">https://1.bp.blogspot.com/-DAAJWGccTCQ/We_MGiMuSFI/AAAAAAAAEtk/5_COppUTDusIIx725jENI3fd9rqlRl0gQCLcBGAs/s64/image8.png</icon>
 	<releases>
-                <release version="2021.3.1.16" date="2022-09-15"/>
+		<release version="2021.3.1.17" date="2022-10-13"/>
+		<release version="2021.3.1.16" date="2022-09-15"/>
 		<release version="2021.2.1.16" date="2022-08-03"/>
 		<release version="2021.2.1.15" date="2022-05-25"/>
 		<release version="2021.2.1.14" date="2022-05-09"/>

--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -108,8 +108,12 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.36.tar.bz2",
-                    "sha256": "bdfe783810fceca9703b9e811817acca63ee9ef0174e616598e8ea6590aa4c9c"
+                    "url": "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.2.40.tar.bz2",
+                    "sha256": "1164b29a75e8ab93ea15033300149e1872a7ef6bdda3d7c78229a735f8204c28"
+                },
+                {
+                    "type": "patch",
+                    "path": "gnupg-a5c3821664886ffffbe6a83aac088a6e0088a607.patch"
                 }
             ]
         },

--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -84,8 +84,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.37.1.tar.xz",
-                    "sha256": "c8162c6b8b8f1c5db706ab01b4ee29e31061182135dc27c4860224aaec1b3500"
+                    "url": "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.38.1.tar.xz",
+                    "sha256": "97ddf8ea58a2b9e0fbc2508e245028ca75911bd38d1551616b148c1aa5740ad9"
                 }
             ]
         },

--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -51,8 +51,8 @@
                     "only-arches": [
                         "x86_64"
                     ],
-                    "url": "https://dl.google.com/dl/android/studio/ide-zips/2021.3.1.16/android-studio-2021.3.1.16-linux.tar.gz",
-                    "sha256": "1a725b585786f43b944336caf703360446e3f4b5e6e234057ff121e50ef91d9a"
+                    "url": "https://dl.google.com/dl/android/studio/ide-zips/2021.3.1.17/android-studio-2021.3.1.17-linux.tar.gz",
+                    "sha256": "89adb0ce0ffa46b7894e7bfedb142b1f5d52c43c171e6a6cb9a95a49f77756ca"
                 },
                 {
                     "type": "script",

--- a/gnupg-a5c3821664886ffffbe6a83aac088a6e0088a607.patch
+++ b/gnupg-a5c3821664886ffffbe6a83aac088a6e0088a607.patch
@@ -1,0 +1,16 @@
+diff --git a/dirmngr/server.c b/dirmngr/server.c
+index 651f67c..87a0d77 100644 (file)
+--- a/dirmngr/server.c
++++ b/dirmngr/server.c
+@@ -3135,8 +3135,10 @@ start_command_handler (assuan_fd_t fd, unsigned int session_id)
+                ctrl->refcount);
+   else
+     {
++#if USE_LDAP
+       ks_ldap_free_state (ctrl->ks_get_state);
+       ctrl->ks_get_state = NULL;
++#endif
+       release_ctrl_ocsp_certs (ctrl);
+       xfree (ctrl->server_local);
+       dirmngr_deinit_default_ctrl (ctrl);
+


### PR DESCRIPTION
- git 2.31.1 to 2.38.1
- gnupg 2.2.36 to 2.2.40
- Dolphin 2021.3.1.16 to 2021.3.1.17