### PR TITLE
Integrate `ide-flatpak-wrapper`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "shared-modules"]
 	path = shared-modules
 	url = https://github.com/flathub/shared-modules.git
+[submodule "ide-flatpak-wrapper"]
+	path = ide-flatpak-wrapper
+	url = https://github.com/flathub/ide-flatpak-wrapper.git

--- a/com.google.AndroidStudio.desktop
+++ b/com.google.AndroidStudio.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Android Studio
-Exec=android-studio
+Exec=android-studio-wrapper
 Icon=com.google.AndroidStudio
 Comment=Development environment for the Android platform
 Terminal=false

--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -3,7 +3,7 @@
     "runtime": "org.freedesktop.Sdk",
     "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
-    "command": "android-studio",
+    "command": "android-studio-wrapper",
     "finish-args": [
         "--socket=x11",
         "--socket=wayland",
@@ -82,6 +82,20 @@
                     "type": "archive",
                     "url": "https://github.com/git-lfs/git-lfs/releases/download/v3.2.0/git-lfs-linux-amd64-v3.2.0.tar.gz",
                     "sha256": "d6730b8036d9d99f872752489a331995930fec17b61c87c7af1945c65a482a50"
+                }
+            ]
+        },
+        {
+            "name": "ide-flatpak-wrapper",
+            "buildsystem": "meson",
+            "config-opts": [
+                "-Deditor_binary=/app/bin/android-studio",
+                "-Dprogram_name=android-studio-wrapper"
+            ],
+            "sources": [
+                {
+                    "type": "dir",
+                    "path": "ide-flatpak-wrapper"
                 }
             ]
         },


### PR DESCRIPTION
This pull request allows `ide-flatpak-wrapper` to be integrated in the Android Studio flatpak.
It allows SDK extensions (such as nodejs, Python, Rust etc) to be put in the sandbox in order to have an easier access to dev tools being sandboxed.

Solves #142 