### PR TITLE
fix: wrong size for extra data

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -47,7 +47,7 @@
                 {
                     "type": "extra-data",
                     "filename": "android-studio.tar.gz",
-                    "size": 1208024832,
+                    "size": 1208103328,
                     "only-arches": [
                         "x86_64"
                     ],


### PR DESCRIPTION
above size was obtained from the following command
```bash
curl -I "https://dl.google.com/dl/android/studio/ide-zips/2023.2.1.18/android-studio-2023.2.1.18-linux.tar.gz"
```