### PR TITLE
Use newer freedesktop platform 23.08

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.google.AndroidStudio",
     "runtime": "org.freedesktop.Sdk",
-    "runtime-version": "22.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "android-studio-wrapper",
     "finish-args": [


### PR DESCRIPTION
A new version of the runtime was recently released, see [here](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0). Brings some updated packages, but they probably won't affect Android Studio.