### PR TITLE
add permission to export options to global menu

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -15,7 +15,8 @@
     "--allow=multiarch",
     "--env=JAVA_HOME=/app/extra/android-studio/jbr",
     "--talk-name=org.freedesktop.Notifications",
-    "--talk-name=org.freedesktop.secrets"
+    "--talk-name=org.freedesktop.secrets" ,
+    "--talk-name=com.canonical.AppMenu.Registrar"
   ],
   "modules": [
     {


### PR DESCRIPTION
add session bus name for syncing various option to global menu for supported desktops such as kde global menu applet