### PR TITLE
Update README.md with alternative SELinux commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ chattr +C $HOME/.var/app/com.google.AndroidStudio/config/.android/avd
 
 ## LLVM
 
-If you need LLVM for flutter app or something else you can install [`SDK Extension for LLVM Project 20`](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm21) and link to Android Studio,
+If you need LLVM for flutter app or something else you can install [`SDK Extension for LLVM Project 21`](https://github.com/flathub/org.freedesktop.Sdk.Extension.llvm21) and link to Android Studio,
 required `build-options` are already present. You can use this commands:
 
 ```sh


### PR DESCRIPTION
Related to #293 and other SELinux issues. 

`setsebool` can be used to set the required SELinux boolean for only the current boot. Might be better for security.