### PR TITLE
add dbus-tools with x-checker-data to fix theme switch

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -20,6 +20,29 @@
   ],
   "modules": [
     {
+      "name": "dbus",
+      "buildsystem": "meson",
+      "config-opts": [
+        "-Dtools=true",
+        "-Dmessage_bus=false",
+        "-Dsystemd=disabled",
+        "-Dx11_autolaunch=disabled"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz",
+          "sha256": "0ba2a1a4b16afe7bceb2c07e9ce99a8c2c3508e5dec290dbb643384bd6beb7e2",
+          "x-checker-data": {
+            "type": "anitya",
+            "project-id": 5356,
+            "stable-only": true,
+            "url-template": "https://dbus.freedesktop.org/releases/dbus/dbus-$version.tar.xz"
+          }
+        }
+      ]
+    },
+    {
       "name": "android-studio",
       "buildsystem": "simple",
       "build-commands": [


### PR DESCRIPTION
Adds the dbus-tools module and configures x-checker-data for automated updates.

Fixes #326 "Sync with OS" automatic theme switch feature