### PR TITLE
Enable Wayland by default if supported fixes #327

### DIFF
--- a/com.google.AndroidStudio.json
+++ b/com.google.AndroidStudio.json
@@ -6,6 +6,7 @@
   "command": "android-studio-wrapper",
   "finish-args": [
     "--socket=x11",
+    "--socket=wayland",
     "--socket=pulseaudio",
     "--socket=ssh-auth",
     "--socket=gpg-agent",


### PR DESCRIPTION
Enable permission to support Wayland out of the box.
