### PR TITLE
Drop the community package related note

### DIFF
--- a/com.google.AndroidStudio.metainfo.xml
+++ b/com.google.AndroidStudio.metainfo.xml
@@ -82,7 +82,6 @@
         </screenshot>
     </screenshots>
     <description>
-        <p>**This is a community package of Android Studio and not officially supported by Android Open Source Project.**</p>
         <p>Android Studio is the official Integrated Development Environment (IDE) for Android app development. Based on the powerful code editor and developer tools from IntelliJ IDEA, Android Studio offers even more features that enhance your productivity when building Android apps, such as:</p>
         <ul>
             <li>A flexible Gradle-based build system</li>


### PR DESCRIPTION
No longer required since the Flathub adds the note automatically.